### PR TITLE
Fix: 자동로그인 하루만에 풀리는 이슈 해결 및 토큰 관리 로직 개선

### DIFF
--- a/SwypApp2nd/Sources/Services/BackEndAuthService.swift
+++ b/SwypApp2nd/Sources/Services/BackEndAuthService.swift
@@ -180,11 +180,16 @@ final class BackEndAuthService {
     static let shared = BackEndAuthService()
 
     private let baseURL: String = {
+    #if DEBUG
         if let host = Bundle.main.infoDictionary?["DEV_BASE_URL"] as? String {
             return "https://\(host)"
-        } else {
-            return ""
         }
+    #else
+        if let host = Bundle.main.infoDictionary?["RELEASE_BASE_URL"] as? String {
+            return "https://\(host)"
+        }
+    #endif
+        return ""
     }()
     
     /// 백엔드: fetch User Data

--- a/SwypApp2nd/Sources/ViewModels/Login/LoginViewModel.swift
+++ b/SwypApp2nd/Sources/ViewModels/Login/LoginViewModel.swift
@@ -55,7 +55,7 @@ class LoginViewModel: ObservableObject {
                             .fetchMemberInfo(accessToken: tokenResponse.accessToken) { result in
                                 switch result {
                                 case .success(let userInfo):
-                                    print("🟢 자동 로그인 성공: \(userInfo.nickname)")
+                                    print("🟢 [LoginViewModel] 카카오 로그인 성공: \(userInfo.nickname)")
                                     self.getUserCheckRate(accessToken: tokenResponse.accessToken) { checkRate in
                                         let user = User(
                                             id: userInfo.memberId,
@@ -69,7 +69,8 @@ class LoginViewModel: ObservableObject {
                                         self.updateUserSession(with: user)
                                     }
                                 case .failure(let error):
-                                    print("🔴 자동 로그인 실패: \(error)")
+                                    print("🔴 [LoginViewModel] 카카오 로그인 실패: \(error)")
+                                    TokenManager.shared.clear(type: .server)
                                 }
                             }
                     case .failure(let error):
@@ -124,7 +125,7 @@ class LoginViewModel: ObservableObject {
                                 .fetchMemberInfo(accessToken: tokenResponse.accessToken) { result in
                                     switch result {
                                     case .success(let userInfo):
-                                        print("🟢 자동 로그인 성공: \(userInfo.nickname)")
+                                        print("🟢 [LoginViewModel] 애플 로그인 성공: \(userInfo.nickname)")
                                         self.getUserCheckRate(accessToken: tokenResponse.accessToken) { checkRate in
                                             let user = User(
                                                 id: userInfo.memberId,
@@ -138,7 +139,8 @@ class LoginViewModel: ObservableObject {
                                             self.updateUserSession(with: user)
                                         }
                                     case .failure(let error):
-                                        print("🔴 자동 로그인 실패: \(error)")
+                                        print("🔴 [LoginViewModel] 애플 로그인 실패: \(error)")
+                                        TokenManager.shared.clear(type: .server)
                                     }
                                 }
                         case .failure(let error):


### PR DESCRIPTION
## ✨ 변경 사항 요약
- 자동로그인 기능 개선 및 토큰 관리 로직 최적화
- 서버 토큰 만료 시 refreshToken을 이용한 재발급 로직 구현
- 무한루프 방지를 위한 토큰 삭제 로직 추가

## 📄 작업 내용 상세 설명
- 카카오/애플 자동로그인 시 서버 accessToken 만료 처리 로직 개선
- fetchMemberInfo 실패 시 refreshToken으로 토큰 재발급 시도하도록 수정
- 서버 토큰이 모두 없을 때 SNS 토큰도 함께 삭제하여 무한루프 방지
- 자동로그인 실패 원인 분석을 위한 로그 메시지 개선

### 🎯 작업 목적
- 하루만에 자동로그인이 풀리는 이슈 해결
- 토큰 만료 시 사용자 경험 개선 (재로그인 없이 자동 토큰 갱신)
- 자동로그인 로직의 안정성 향상

### 🛠️ 주요 변경 사항
- `UserSession.swift`: `tryKakaoAutoLogin()`, `tryAppleAutoLogin()` 메소드 개선
- fetchMemberInfo 실패 시 refreshToken 재발급 로직 추가
- 토큰 삭제 로직을 통한 무한루프 방지 구현
- 자동로그인 흐름 전반적인 리팩토링

### 📸 스크린샷 (필요시 추가)
<!-- 로그인 화면 또는 자동로그인 관련 스크린샷 추가 -->

### ✅ 체크리스트
- [x] 빌드가 정상적으로 수행됩니다.
- [ ] SwiftLint 규칙을 준수합니다.
- [ ] 관련 문서(README, 문서화 등)를 업데이트 했습니다.
- [ ] 테스트 코드를 작성했습니다. (해당 시)

### ⚠️ 주의사항 및 참고사항
- 서버의 fetchMemberInfo API에서 500 에러가 발생하는 이슈가 확인됨 
- 자동로그인 테스트 시 다양한 토큰 만료 시나리오 확인 필요

### ✅ 참고 이슈 및 관련 작업
- 관련 이슈: 자동로그인이 하루만에 풀리는 문제 #125 